### PR TITLE
Fix InteractiveServer attribute assignment

### DIFF
--- a/Fun.Blazor/DslCore.fs
+++ b/Fun.Blazor/DslCore.fs
@@ -192,18 +192,18 @@ type html() =
     static member inline blazor<'T when 'T :> IComponent>(renderMode: IComponentRenderMode, ?attr: AttrRenderFragmentWrapper) =
         NodeRenderFragment(fun comp builder index ->
             builder.OpenComponent<'T>(index)
-            builder.AddComponentRenderMode(renderMode)
 
             let nextIndex =
                 match attr with
                 | Some(AttrRenderFragmentWrapper attr) -> attr.Invoke(comp, builder, index + 1)
                 | None -> index + 1
 
+            builder.AddComponentRenderMode(renderMode)
             builder.CloseComponent()
             nextIndex
         )
 
-    /// This has to be used together with _framework/blazor.web.js. 
+    /// This has to be used together with _framework/blazor.web.js.
     /// For more information please go to https://learn.microsoft.com/en-us/aspnet/core/blazor/components/rendering?view=aspnetcore-8.0#streaming-rendering
     static member inline streaming (node: NodeRenderFragment) =
         html.blazor<FunStreamingComponent>(nameof Unchecked.defaultof<FunStreamingComponent>.Content => node)


### PR DESCRIPTION
After the dotnet8 upgrade, using `html.blazor` with `RenderMode.InteractiveServer` and passing in extra attributes causes the following exception: `InvalidOperationException: Attributes may only be added immediately after frames of type Element or Component`.

This exception comes from [Blazor](https://github.com/dotnet/aspnetcore/blob/77685932e959ef222707a8d53df7ad09eb33a398/src/Components/Components/src/Rendering/RenderTreeBuilder.cs#L715).

The fix introduced here moves the call to `AddComponentRenderMode` to after adding the custom attributes.

The sample component throwing this exception can be found below:

```fsharp
type Edit() =
    inherit FunComponent()

    [<Parameter>]
    member val Id: int = 0 with get, set

    override this.Render() = renderEdit this.Id

    member _.edit(id: int) =
        let attrs =
            domAttr {
                "id" => id
                asAttrRenderFragment
            }

        html.blazor<Edit>
            RenderMode.InteractiveServer
            (AttrRenderFragmentWrapper attrs)
```