### PR TITLE
docs: document trailing-apostrophe DSL naming (html', class', type')

### DIFF
--- a/Fun.Blazor/CHANGELOG.md
+++ b/Fun.Blazor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Document trailing-apostrophe DSL naming convention (`html'`, `class'`, `type'`)
+
 ## [4.1.10] - 2026-01-08
 
 - Support `lazyValidate` for AdaptiveForm and UseAdaptiveForm

--- a/Fun.Blazor/DslCore.fs
+++ b/Fun.Blazor/DslCore.fs
@@ -14,6 +14,13 @@ open Microsoft.AspNetCore.Components.Web
 #endif
 
 
+/// Static helpers for building Fun.Blazor render fragments, such as
+/// <c>html.raw</c>, <c>html.inject</c>, <c>html.fragment</c>, <c>html.blazor</c>,
+/// and others.
+///
+/// Note: this class does not represent the <c>&lt;html&gt;</c> root element.
+/// For that element CE, use <c>html'</c> (apostrophe-escaped to disambiguate
+/// from this class). See README for the naming convention.
 type html() =
 
     /// Helper method to create an empty node

--- a/README.md
+++ b/README.md
@@ -63,6 +63,33 @@ type CountPage() =
     }
 ```
 
+## Naming convention: trailing apostrophe
+
+Some DSL names would collide with F# keywords or with other identifiers in scope.
+The Fun.Blazor DSL disambiguates those with a trailing apostrophe:
+
+- `class'` — sets the `class` attribute (`class` is an F# keyword)
+- `type'` — sets the `type` attribute (`type` is an F# keyword)
+- `html'` — the `<html>` root element CE (the bare `html` is a static utility
+  class that owns helpers such as `html.raw`, `html.inject`, `html.fragment`)
+
+So a full document is authored as:
+
+```fsharp
+fragment {
+    html.raw "<!DOCTYPE html>"
+    html' {
+        lang "en"
+        head { title { "My app" } }
+        body { ... }
+    }
+}
+```
+
+Writing the bare `html { ... }` instead produces
+`FS0501: The object constructor 'html' takes 0 argument(s) but is here given 1`
+because F# resolves the bare name to the static class above.
+
 ## Local development
 
 You can run **dotnet fsi build.fsx -- -h** to check what is available to help you get started.


### PR DESCRIPTION
## Summary

Documents the trailing-apostrophe DSL naming convention so users don't mistake
it for a library gap. No behavior changes, no API additions.

Three small additions:

- **XML doc on `type html()`** in `Fun.Blazor/DslCore.fs` — clarifies that the
  static class does not represent the `<html>` element and cross-references
  `html'`. Surfaces in IntelliSense on hover.
- **README subsection** — covers the apostrophe convention with the document
  root as a worked example, and names the specific F# compiler error
  (`FS0501: The object constructor 'html' takes 0 argument(s) but is here given 1`)
  a reader will hit if they reach for the bare `html`.
- **CHANGELOG entry** under `[Unreleased]`.

## Why

While integrating Fun.Blazor 4.1.10 into an F# app, I (and an AI pair-programmer)
spent meaningful time treating `<html>` as a missing element CE — even drafting
a fork plan around adding one — before noticing that `html'` already ships at
[`DslElementBuilder.generated.fs:799`](https://github.com/slaveOftime/Fun.Blazor/blob/master/Fun.Blazor/DslElementBuilder.generated.fs#L799). The convention is well-established
internally (`class'`, `type'`) and `html'` is even already used in
[`Docs/40 Advanced/80 Htmx/README.md`](https://github.com/slaveOftime/Fun.Blazor/blob/master/Docs/40%20Advanced/80%20Htmx/README.md), but it isn't surfaced on the obvious
discovery paths: the top-level README, or the doc summary on the static `html`
class that a new user first encounters via `html.inject` / `html.raw`. This
patch fixes that.

LLM-assisted authoring benefits especially: assistants default to the bare
element name and need the convention spelled out somewhere reachable to
recover from the FS0501 dead-end.

## Test plan

- [x] `dotnet build Fun.Blazor/Fun.Blazor.fsproj -c Release` — clean across
  net6.0 / net8.0 / net9.0, 0 warnings, 0 errors.
- No behavior changes; no tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)